### PR TITLE
Update weather radar to reference new Ridge Lite loop

### DIFF
--- a/src/components/WeatherCard.js
+++ b/src/components/WeatherCard.js
@@ -37,7 +37,7 @@ function WeatherCard(props) {
         </CardContent>
         <CardMedia
           className={classes.media}
-          image="https://radar.weather.gov/Conus/Loop/centgrtlakes_loop.gif"
+          image="https://radar.weather.gov/ridge/lite/CENTGRLAKES_loop.gif"
           title="Great Lakes Radar Loop"
         />
         <CardActions>


### PR DESCRIPTION
In December 2020, NOAA discontinued the CONUS radar loop used by this application.

To Do:

- [x] Pull the newly available "Ridge Lite" Great Lakes loop instead.
- [ ] Display weather warnings in a format compliant with upcoming NWS language changes